### PR TITLE
Add a note to change the filesystem type too

### DIFF
--- a/docs/filesharing/mounting-external-drive.md
+++ b/docs/filesharing/mounting-external-drive.md
@@ -61,7 +61,7 @@ Now open the fstab file:
 sudo nano /etc/fstab
 ```
 
-and add the following lines, replacing with your UUID and mount location:
+and add the following lines, replacing with your UUID, mount location and filesystem type (e.g. ntfs, fat32, ext4):
 
 ```
 UUID=D632-BE5F /mnt/exdisk fstype defaults,auto,users,rw,nofail 0 0


### PR DESCRIPTION
Following the guide one might leave the `fstype` verbatim in the `fstab` entry like

```
UUID=D632-BE5F /mnt/exdisk fstype defaults,auto,users,rw,nofail 0 0
```

This leads to the following error:

```
sudo mount -a
mount: /mnt/HDD: unknown filesystem type 'fstype'.
```

Since the previous command already shows the filesystem type, simply asking to update it should be enough.